### PR TITLE
Flip and compose_n

### DIFF
--- a/include/fu/README.md
+++ b/include/fu/README.md
@@ -133,20 +133,24 @@ constexpr auto fact = fix([](auto rec, int x) -> int {
 });
 ```
 
-## compose(f,g) and ucompose(f,g)
+## compose(f,g), ucompose(f,g), compose_n<n>(f,g)
 
 Many useful forms of composition exist, but `compose(f,g)` is the most general.
 It returns a function, `c`, that takes two tuples, `{x...}` and `{y...}`, such
 that `c({x...}, {y...})` computes `f(g(x...), y...)`. For most instances,
 `u = ucompose(f,g)` is much simpler; `u(x,y...)` computes `f(g(x), y...)`--it
-is short for "unary composition".
+is short for "unary composition". It assumes that `g` is unary, but often it
+may not be. `compose_n<n>(f,g)` sends the first `n` arguments to `g` and the
+rest to `f`.
 ```c++
 void f(int, int, int);
 void g(int, int);
 constexpr auto fg = compose(f,g);
+constexpr auto fg2 = compose_n<2>(f,g)
 
 using fu::tpl::tuple;
 fg(tuple(1,2), tuple(3,4));  // computes: f(g(1,2), 3, 4)
+fg2(1,2,3,4);                // computes: f(g(1,2), 3, 4)
 
 void h(int);
 constexpr auto fh = ucompose(f,h);

--- a/include/fu/README.md
+++ b/include/fu/README.md
@@ -179,6 +179,16 @@ std::accumulate(first, last, 0, rproj(std::plus<>{}, &std::string::size));
 computes `f(l(x), r(x))`. `join(f,l,r)` takes exactly two arguments, `x` and
 `y`, and computes `f(l(x), r(y))`.
 
+## flip(f)
+
+`flip(f)` reverses the order of arguments applied to `f`.
+```c++
+static_assert(fu::flip(fu::sub)(y,x) == fu::sub(x,y));
+
+auto h(A, B, C, D);
+flip(h, d, c, b, a);  // invokes: h(a,b,c,d)
+```
+
 ## constant(x)
 
 `constant(x)` returns a nullary function (takes no arguments) that always

--- a/include/fu/basic.h
+++ b/include/fu/basic.h
@@ -186,18 +186,6 @@ constexpr auto closure = MakeT<Part>{};
 /// Like closure, but forwards its arguments.
 constexpr auto part = ForwardT<Part>{};
 
-/// Specialization for embedded Parts. (Produces better error messages.)
-template<class F, class...X, class...Y>
-struct Part <Part<F,X...>, Y...> : Part<F, X..., Y...> {
-  constexpr Part(Part<F,X...> p1, Y...y)
-    : Part<F, X..., Y...>(tpl::apply(part,
-                                     std::tuple_cat(std::make_tuple(std::move(p1.f)),
-                                                    std::move(p1.t),
-                                                    tpl::forward_tuple(std::forward<Y>(y)...))))
-  {
-  }
-};
-
 /// A function that takes `n` or more arguments. If given only one argument, it
 /// will return a partial application.
 template<size_t n, class _F>

--- a/include/fu/functional.h
+++ b/include/fu/functional.h
@@ -353,6 +353,26 @@ struct split_f {
 /// split(f,l,r)(x) <=> f(l(x), r(x))
 constexpr auto split = multary_n<3>(split_f{});
 
+struct flip_f {
+  template<class I, I...i, class F, class...X>
+  static constexpr decltype(auto) reverse(std::integer_sequence<I,i...>,
+                                          F&& f,
+                                          std::tuple<X...> args)
+  {
+    return fu::invoke(std::forward<F>(f),
+                      std::get<sizeof...(X) - i - 1>(std::move(args))...);
+  }
+
+  template<class F, class...X>
+  constexpr decltype(auto) operator() (F&& f, X&&...x) const {
+    return reverse(std::index_sequence_for<X...>{},
+                   std::forward<F>(f),
+                   tpl::forward_tuple(std::forward<X>(x)...));
+  }
+};
+
+constexpr auto flip = multary_n<2>(flip_f{});
+
 template<template<class...>class Enabler, class F>
 struct Enabled_f {
   F f;

--- a/include/fu/iseq.h
+++ b/include/fu/iseq.h
@@ -38,17 +38,13 @@ constexpr auto push(std::integer_sequence<I, N...>, Integer<I, M>)
 
 template<size_t X, class I, I...N,
          class = typename std::enable_if<(X == 0)>::type>
-constexpr auto drop(std::integer_sequence<I, N...> i)
-  -> decltype(i)
-{
+constexpr auto drop(std::integer_sequence<I, N...> i) {
   return i;
 }
 
 template<size_t X, class I, I N, I...M,
          class = typename std::enable_if<(X > 0)>::type>
-constexpr auto drop(std::integer_sequence<I, N, M...>)
-  -> decltype(drop<X - 1>(std::integer_sequence<I, M...>{}))
-{
+constexpr auto drop(std::integer_sequence<I, N, M...>) {
   static_assert(X <= sizeof...(M) + 1, "Index too high.");
   return drop<X - 1>(std::integer_sequence<I, M...>{});
 }
@@ -56,9 +52,7 @@ constexpr auto drop(std::integer_sequence<I, N, M...>)
 template<size_t X, class I, I...N, I...M,
          class = typename std::enable_if<(X == 0)>::type>
 constexpr auto take(std::integer_sequence<I, N...> i,
-                    std::integer_sequence<I, M...>)
-  -> decltype(i)
-{
+                    std::integer_sequence<I, M...>) {
   return i;
 }
 
@@ -73,9 +67,7 @@ constexpr auto take(std::integer_sequence<I, N...> i,
 
 template<size_t X, class I, I...N>
 constexpr auto take(std::integer_sequence<I, N...> i)
-  -> decltype(take<X>(std::integer_sequence<I>{}, i))
-{
-  return take<X>(std::integer_sequence<I>{}, i);
+{ return take<X>(std::integer_sequence<I>{}, i);
 }
 
 } // namespace iseq

--- a/test/functional.cpp
+++ b/test/functional.cpp
@@ -45,6 +45,16 @@ int main() {
   static_assert(_add3(1)(1)(1) == 3, "");
 #endif
 
+  constexpr auto g = fu::compose_n<2>(add3, add_half);
+  static_assert(g(1,1,1,1) == 3, "");
+  static_assert(g(2,2,1,1) == 4, "");
+
+  static_assert(fu::flip(g)(1,1,2,2) == 4, "");
+  static_assert(fu::flip(g,1,1,2,2) == 4, "");
+
+  static_assert(fu::flip(fu::sub, 5, 10) == 5, "flip(-,5,10) <=> 10 - 5");
+  static_assert(fu::flip(fu::less, 5, 4, 3, 2, 1), "");
+
   constexpr auto pow2 = fu::fix(unfixed_pow2);
   GCC_STATIC_ASSERT(pow2(0) == 1);
   GCC_STATIC_ASSERT(pow2(1) == 2);

--- a/test/functional.cpp
+++ b/test/functional.cpp
@@ -20,7 +20,16 @@ constexpr struct unfixed_pow2_f {
   }
 } unfixed_pow2{};
 
+constexpr int divide(int x, int y) {
+    return x / y;
+}
+
 int main() {
+  static_assert(fu::rassoc(divide, 10,2) == 10/2, "");
+  static_assert(fu::rassoc(divide, 10,8,4) == 10/(8/4), "");
+  static_assert(fu::rassoc(divide, 10,8,8,2) == 10/(8/(8/2)), "");
+  static_assert(fu::rassoc(divide)(10,8,8,2) == 10/(8/(8/2)), "");
+
   // FIXME: gcc cannot evaluate some tests as constexpr, although clang can,
   // and it's vice versa for other tests.
 #ifdef __clang__

--- a/test/functional.cpp
+++ b/test/functional.cpp
@@ -45,6 +45,9 @@ int main() {
   static_assert(_add3(1)(1)(1) == 3, "");
 #endif
 
+  static_assert(fu::rproj(fu::mult)(fu::add(1))(1,0) == 1, "");
+  static_assert(fu::rproj(fu::mult, fu::add(1))(1,0) == 1, "");
+
   constexpr auto g = fu::compose_n<2>(add3, add_half);
   static_assert(g(1,1,1,1) == 3, "");
   static_assert(g(2,2,1,1) == 4, "");


### PR DESCRIPTION
Two generic functions that allow one to define `lassoc` in terms of `rassoc` and `rproj` in terms of `lproj`.
