### PR TITLE
fu::logic module

### DIFF
--- a/include/fu/logic.h
+++ b/include/fu/logic.h
@@ -1,0 +1,2 @@
+
+#include <fu/logic/logic.h>

--- a/include/fu/logic/README.md
+++ b/include/fu/logic/README.md
@@ -10,9 +10,29 @@ less(x,y,z);  // computes and(less(x,y), less(y,z))
 ```
 While this version of `less` is correct, `less(x,y)` and `less(y,z)` must both
 be computed, even if `less(x,y)` returns false--but `less(x,y) && less(y,z)`
-would short-circuit if this first one failed.
+would short-circuit if this first one failed. `transitive` is too generic to
+make a good `less`.
 
-TODO: complete example
+`fu::logic::logical_transitive` can be used to create short-circuit logical
+evaluations, although its interface looks quite obscure.
+```c++
+auto less = logical_transitive(false, identity, std::less<>{});
+less(1,2,3);  // computes 1 < 2 && 2 < 3
+less(3,2,1);  // computes 3 < 2 and stops
+```
+## logical_transitive
+
+All of the relational operations from `"fu/utility.h"` define themselves by
+`op = logical_transitive(identity, eval, predicate)`. `identity` represents the
+identity element of the operation (`true` for `and` and `false` for `or`),
+`eval` returns a boolean deciding whether to recurse or not, and `predicate` is
+the actual function evaluating the arguments.
+
+Given `op(a,b,c,d)`, first `eval(predicate(a,b))` will be computed. If false,
+then it returns `identity`, or otherwise will compose `eval(predicate(b,c))`
+and repeat until the argument list ends.
+
+*(See above for code example.)*
 
 ## logical_project(identity, eval, pred), all, and any
 

--- a/include/fu/logic/README.md
+++ b/include/fu/logic/README.md
@@ -1,0 +1,33 @@
+
+# fu::logic
+
+`"fu/logic.h"` includes a number of functions that take advantage of the
+properties of logical operations. Consider `fu::transitive(binary, join)`.
+```c++
+// transitive(b,j)(x,y,z) <=> j(b(x,y), b(y,z))
+auto less = transitive(std::less<>{}, std::logical_and<>{});
+less(x,y,z);  // computes and(less(x,y), less(y,z))
+```
+While this version of `less` is correct, `less(x,y)` and `less(y,z)` must both
+be computed, even if `less(x,y)` returns false--but `less(x,y) && less(y,z)`
+would short-circuit if this first one failed.
+
+TODO: complete example
+
+## logical_project(identity, eval, pred), all, and any
+
+`logical_project` is an overly-generic function that will test every argument,
+`x_i`, with `eval(pred(x_i))` and returns `identity` when false. With only one
+argument, it returns `eval(x)`. As it happens, `all(f)` and `any(f)` can be
+defined in terms of `logical_project`.
+```c++
+/// all(pred)(x....) <=> pred(x) && ...
+constexpr auto all = logical_project(false, identity);
+
+/// any(pred)(x...) <=> pred(x) || ...
+constexpr auto any = logical_project(true, not_);
+
+auto big = [](int x) { return x > 5; };
+assert(any(big, 3, 4, 5, 6));
+assert(all(big, 6, 7, 8, 9));
+```

--- a/include/fu/logic/logic.h
+++ b/include/fu/logic/logic.h
@@ -62,5 +62,8 @@ constexpr auto all = logical_project(false, identity);
 /// any(pred)(x...) <=> pred(x) || ...
 constexpr auto any = logical_project(true, basic_not);
 
+/// none(pred)(x...) <=> !pred(x) && ...
+constexpr auto none = multary(mcompose(basic_not, any));
+
 } // namespace logic
 } // namespace fu

--- a/include/fu/logic/logic.h
+++ b/include/fu/logic/logic.h
@@ -1,0 +1,42 @@
+
+
+#include <fu/functional.h>
+#include <fu/utility.h>
+
+namespace fu {
+namespace logic {
+
+/// Logical function projection.
+/// Invokes short-circuit logical operations on a predicate, p.
+///
+/// logical_project(ident,ok,p,x,y) <=> ok(p(x)) ? p(y) : ident
+/// logical_project(false,id,p,x,y) <=> p(x) ? p(y) : false
+/// logical_project(true,(!),p,x,y) <=> !p(x) ? p(y) : true
+struct logical_project_f {
+  template<class Identity, class Ok, class Pred, class X>
+  constexpr decltype(auto) operator() (const Identity&, const Ok&,
+                                       Pred&& p, X&& x) const {
+    return fu::invoke(std::forward<Pred>(p), std::forward<X>(x));
+  }
+
+  template<class Identity, class Ok, class Pred, class X, class...Y,
+           class = enable_if_t<(sizeof...(Y) > 0)>>
+  constexpr decltype(auto) operator() (Identity&& id, Ok&& ok,
+                                       Pred&& p, X&& x, Y&&...y) const {
+    return fu::invoke(ok, fu::invoke(p, std::forward<X>(x)))
+      ? (*this)(std::forward<Identity>(id), std::forward<Ok>(ok),
+                std::forward<Pred>(p), std::forward<Y>(y)...)
+      : std::forward<Identity>(id);
+  }
+};
+
+constexpr auto logical_project = multary_n<3>(logical_project_f{});
+
+/// all(pred)(x....) <=> pred(x) && ...
+constexpr auto all = logical_project(false, identity);
+
+/// any(pred)(x...) <=> pred(x) || ...
+constexpr auto any = logical_project(true, not_);
+
+} // namespace logic
+} // namespace fu

--- a/include/fu/utility.h
+++ b/include/fu/utility.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <fu/functional.h>
+#include <fu/logic.h>
 
 namespace fu {
 
@@ -57,10 +58,25 @@ struct bit_and_f {
 };
 constexpr auto bit_and = numeric_binary(bit_and_f{});
 
+// Helper to define unary operators.
+#define DECL_UNARY(name, op)                               \
+  constexpr struct name##_f {                              \
+    template<class X>                                      \
+    constexpr decltype(auto) operator() (X&& x) const      \
+    { return op std::forward<X>(x); }                      \
+  } name{};
+
+DECL_UNARY(pos,   +);
+DECL_UNARY(neg,   -);
+DECL_UNARY(not_,  !);
+DECL_UNARY(deref, *);
+DECL_UNARY(addr,  &);  // TODO: Use std::address_of().
+
 constexpr struct numeric_relational_f {
-  template<class Binary, class Join = and__f>
-  constexpr auto operator() (Binary b, Join j = Join{}) const {
-    return multary(transitive(b, j));
+  template<class Binary, class Identity=bool, class Ok=identity_f>
+  constexpr auto operator() (Binary b, Identity ident=false, Ok ok = Ok{}) const
+  {
+    return logic::logical_transitive(ident, ok, b);
   }
 } numeric_relational{};
 
@@ -81,20 +97,6 @@ DECL_REL_OP(eq,         ==);
 DECL_REL_OP(neq,        !=);
 DECL_REL_OP(less_eq,    <=);
 DECL_REL_OP(greater_eq, >=);
-
-// Helper to define unary operators.
-#define DECL_UNARY(name, op)                               \
-  constexpr struct name##_f {                              \
-    template<class X>                                      \
-    constexpr decltype(auto) operator() (X&& x) const      \
-    { return op std::forward<X>(x); }                      \
-  } name{};
-
-DECL_UNARY(pos,   +);
-DECL_UNARY(neg,   -);
-DECL_UNARY(not_,  !);
-DECL_UNARY(deref, *);
-DECL_UNARY(addr,  &);  // TODO: Use std::address_of().
 
 #undef DECL_BIN_OP
 #undef DECL_REL_OP

--- a/include/fu/utility.h
+++ b/include/fu/utility.h
@@ -57,10 +57,12 @@ struct bit_and_f {
 };
 constexpr auto bit_and = numeric_binary(bit_and_f{});
 
-template<class Binary, class Join = and__f>
-constexpr auto numeric_relational(Binary b, Join j = Join{}) {
-  return multary(transitive(b, j));
-}
+constexpr struct numeric_relational_f {
+  template<class Binary, class Join = and__f>
+  constexpr auto operator() (Binary b, Join j = Join{}) const {
+    return multary(transitive(b, j));
+  }
+} numeric_relational{};
 
 // Helper to define binary relations.
 #define DECL_REL_OP(name, op)                              \

--- a/test/logic.cpp
+++ b/test/logic.cpp
@@ -1,0 +1,22 @@
+
+#include <fu/logic.h>
+
+constexpr struct basic_less_f {
+  template<class X, class Y>
+  constexpr bool operator() (const X& x, const Y& y) const {
+    return x < y;
+  }
+} basic_less{};
+
+int main() {
+  using namespace fu::logic;
+
+  constexpr auto larger_than_10 = fu::part(basic_less, 10);
+  static_assert(all(larger_than_10, 11, 14, 20), "");
+  static_assert(!all(larger_than_10, 11, 14, 9), "");
+  static_assert(!all(larger_than_10, 1, 14, 11), "");
+
+  static_assert(any(larger_than_10, 11, 14, 20), "");
+  static_assert(any(larger_than_10, 11, 4, 9), "");
+  static_assert(!any(larger_than_10, 1, 4, 5), "");
+}

--- a/test/logic.cpp
+++ b/test/logic.cpp
@@ -19,4 +19,8 @@ int main() {
   static_assert(any(larger_than_10, 11, 14, 20), "");
   static_assert(any(larger_than_10, 11, 4, 9), "");
   static_assert(!any(larger_than_10, 1, 4, 5), "");
+
+  static_assert(none(larger_than_10, 1, 3, 4), "");
+  static_assert(none(larger_than_10)(1, 3, 4), "");
+  static_assert(!none(larger_than_10, 1, 11, 4), "");
 }


### PR DESCRIPTION
Adds efficient transformations for logical operations.

``` c++
all(f,x,y,z) <=> f(x) && f(y) && f(z)
any(f,x,y,z) <=> f(x) || f(y) || f(z)
```

Improves implementation of `"fu/utility.h"` by allowing short-circuiting of functions like `less`.

``` c++
// old behaviour
less(x,y,z)  <=>  fu::and_(x < y, y < z);

// new behaviour
less(x,y,z)  <=>  x < y && y < z
```
